### PR TITLE
Add Dev-Only User Switcher for Testing & Demo Purposes

### DIFF
--- a/client/client_tree.txt
+++ b/client/client_tree.txt
@@ -6,44 +6,88 @@ client
 ├── package-lock.json
 ├── package.json
 ├── public
-│   └── vite.svg
+│   └── favicon.png
 ├── src
 │   ├── App.jsx
 │   ├── api
-│   │   └── axios.js
+│   │   ├── axios.js
+│   │   └── goalsApi.js
 │   ├── assets
-│   │   └── react.svg
+│   │   ├── logo.png
+│   │   └── work.png
 │   ├── components
+│   │   ├── AnimatedCard.jsx
 │   │   ├── Button.jsx
-│   │   └── Layout
-│   │       ├── Footer.jsx
-│   │       ├── Header.jsx
-│   │       └── Layout.jsx
+│   │   ├── DeckCard.jsx
+│   │   ├── Flashcard.jsx
+│   │   ├── Input.jsx
+│   │   ├── Layout
+│   │   │   ├── Footer.jsx
+│   │   │   ├── GoalForm.jsx
+│   │   │   ├── GoalsList.jsx
+│   │   │   ├── Header.jsx
+│   │   │   ├── Layout.jsx
+│   │   │   └── Sidebar.jsx
+│   │   ├── PageWrapper.jsx
+│   │   ├── TestAuth.jsx
+│   │   ├── Textarea.jsx
+│   │   ├── ToggleSwitch.jsx
+│   │   ├── UIShowcase.jsx
+│   │   └── development
+│   │       └── UserSwitcher.jsx
+│   ├── features
+│   │   ├── auth
+│   │   │   └── authSlice.js
+│   │   ├── decks
+│   │   │   └── decksSlice.js
+│   │   ├── flashcards
+│   │   │   └── flashcardsSlice.js
+│   │   ├── goals
+│   │   │   └── goalsSlice.js
+│   │   └── user
+│   │       └── userSlice.js
 │   ├── hooks
-│   │   └── useExample.js
+│   │   ├── useExample.js
+│   │   ├── useGoals.js
+│   │   └── useIsMobile.js
 │   ├── main.jsx
 │   ├── pages
-│   │   └── HomePage.jsx
+│   │   ├── Dashboard.jsx
+│   │   └── Decks.jsx
+│   ├── store.js
 │   ├── styles
 │   │   ├── base
 │   │   │   ├── _globals.scss
 │   │   │   ├── _reset.scss
-│   │   │   └── _typography.scss
+│   │   │   ├── _typography.scss
+│   │   │   └── index.scss
 │   │   ├── components
 │   │   │   ├── _app.scss
-│   │   │   └── _buttons.scss
+│   │   │   ├── _buttons.scss
+│   │   │   ├── _deckcard.scss
+│   │   │   ├── _flashcard.scss
+│   │   │   ├── _input.scss
+│   │   │   ├── _textarea.scss
+│   │   │   ├── _toggleswitch.scss
+│   │   │   ├── _uishowcase.scss
+│   │   │   └── index.scss
 │   │   ├── layouts
 │   │   │   ├── _footer.scss
 │   │   │   ├── _grid.scss
 │   │   │   ├── _header.scss
-│   │   │   └── _layout.scss
+│   │   │   ├── _layout.scss
+│   │   │   ├── _sidebar.scss
+│   │   │   └── index.scss
 │   │   ├── main.scss
 │   │   ├── pages
-│   │   │   └── _home.scss
+│   │   │   ├── _dashboard.scss
+│   │   │   ├── _decks.scss
+│   │   │   └── index.scss
 │   │   └── utils
-│   │       └── _variables.scss
+│   │       ├── _variables.scss
+│   │       └── index.scss
 │   └── utils
 │       └── helpers.js
 └── vite.config.js
 
-15 directories, 31 files
+22 directories, 68 files

--- a/client/src/api/axios.js
+++ b/client/src/api/axios.js
@@ -1,7 +1,8 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: import.meta.env.VITE_API_URL, // uses .env configuration
+  withCredentials: true, // needed for sessions/cookies use
 });
 
 export default api;

--- a/client/src/components/Layout/Sidebar.jsx
+++ b/client/src/components/Layout/Sidebar.jsx
@@ -1,35 +1,44 @@
-import { Link } from 'react-router-dom';
-import studysyncLogo from "../../assets/logo.png";	
-import { LayoutDashboard, Target, Library, LogOut } from 'lucide-react';
+import { Link } from "react-router-dom";
+import studysyncLogo from "../../assets/logo.png";
+import { LayoutDashboard, Target, Library, LogOut } from "lucide-react";
+import DevUserSwitcher from "../development/UserSwitcher"; // required for dev/test environment and MVP demo
 // import Goals from '../../pages/Goals';
 // import Decks from '../../pages/Decks';
 // import Study from './pages/Study';
 
 const Sidebar = () => {
-
-
   return (
     <div className="sidebar">
       <img src={studysyncLogo} className="logo" alt="StudySync logo" />
       <nav className="nav-links">
         <ul>
           <li>
-            <Link to="/"><LayoutDashboard /> Dashboard</Link>
+            <Link to="/">
+              <LayoutDashboard /> Dashboard
+            </Link>
           </li>
           <li>
-            <Link to="/goals"><Target /> Goals</Link>
+            <Link to="/goals">
+              <Target /> Goals
+            </Link>
           </li>
           <li>
-            <Link to="/decks"><Library /> Decks</Link>
+            <Link to="/decks">
+              <Library /> Decks
+            </Link>
           </li>
         </ul>
         <ul className="logout">
           <li>
-            <Link to="/logout"><LogOut /> Logout</Link>
+            <DevUserSwitcher />
+          </li>
+          <li>
+            <Link to="/logout">
+              <LogOut /> Logout
+            </Link>
           </li>
         </ul>
       </nav>
-
     </div>
   );
 };

--- a/client/src/components/development/UserSwitcher.jsx
+++ b/client/src/components/development/UserSwitcher.jsx
@@ -1,0 +1,79 @@
+import api from "../../api/axios";
+import Button from "../Button";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  loginStart,
+  loginSuccess,
+  loginFailure,
+} from "../../features/auth/authSlice";
+
+// Define known demo user credentials
+const demoUsers = [
+  {
+    email: "alice@studysync.com",
+    password: "password",
+    username: "Alice Demo",
+  },
+  {
+    email: "bob@studysync.com",
+    password: "password",
+    username: "Bob Demo",
+  },
+  {
+    email: "carol@studysync.com",
+    password: "password",
+    username: "Carol Demo",
+  },
+];
+
+const DevUserSwitcher = () => {
+  const dispatch = useDispatch();
+  const { user } = useSelector((state) => state.auth);
+
+  // Only render in development mode
+  if (import.meta.env.MODE !== "development") return null;
+
+  const handleSwitch = async ({ email, password }) => {
+    dispatch(loginStart());
+
+    try {
+      const res = await api.post("/api/v1/login", { email, password });
+      dispatch(loginSuccess(res.data.user)); // match your backend structure
+    } catch (err) {
+      dispatch(loginFailure("Failed to log in as user"));
+      console.error("Login error:", err);
+    }
+  };
+
+  return (
+    <div className="dev-user-switcher">
+      <p style={{ fontSize: "0.75rem", marginBottom: "0.5rem" }}>
+        <strong>Switch User (Dev)</strong>
+      </p>
+      <p style={{ fontSize: "0.75rem", marginBottom: "0.5rem", color: "#555" }}>
+        Logged in as: <strong>{user?.username || "None"}</strong>
+      </p>
+      {demoUsers.map((demoUser) => (
+        <button
+          key={demoUser.email}
+          onClick={() => handleSwitch(demoUser)}
+          style={{
+            fontSize: "0.75rem",
+            margin: "2px 0",
+            padding: "4px 6px",
+            borderRadius: "4px",
+            backgroundColor: "#be1b1b",
+            border: "1px solid #ccc",
+            cursor: "pointer",
+            width: "100%",
+            textAlign: "left",
+          }}
+        >
+          {demoUser.username}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default DevUserSwitcher;

--- a/server/config/initializers/cors.rb
+++ b/server/config/initializers/cors.rb
@@ -7,11 +7,12 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "http://localhost:5173" # Change to your frontend domain in production
+    origins "http://localhost:5173", "http://127.0.0.1:5173" # Change to your frontend domain in production
     # You can restrict origins to your React frontend URL (e.g., localhost:5173) in development if needed.
 
     resource "*",
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true  # Required for session/cookie support
   end
 end

--- a/server/server_tree.txt
+++ b/server/server_tree.txt
@@ -1,4 +1,4 @@
-.
+server
 ├── Dockerfile
 ├── Gemfile
 ├── Gemfile.lock
@@ -12,21 +12,73 @@
 │   ├── controllers
 │   │   ├── api
 │   │   │   └── v1
-│   │   │       └── example_controller.rb
+│   │   │       ├── dashboard_controller.rb
+│   │   │       ├── decks_controller.rb
+│   │   │       ├── flashcard_reviews_controller.rb
+│   │   │       ├── flashcards_controller.rb
+│   │   │       ├── goals_controller.rb
+│   │   │       ├── sessions_controller.rb
+│   │   │       ├── study_sessions_controller.rb
+│   │   │       └── users_controller.rb
 │   │   ├── application_controller.rb
-│   │   └── concerns
+│   │   ├── concerns
+│   │   └── welcome_controller.rb
 │   ├── jobs
 │   │   └── application_job.rb
 │   ├── mailers
 │   │   └── application_mailer.rb
 │   ├── models
+│   │   ├── activity_log.rb
+│   │   ├── ai_request.rb
 │   │   ├── application_record.rb
-│   │   └── concerns
+│   │   ├── badge.rb
+│   │   ├── challenge.rb
+│   │   ├── comment.rb
+│   │   ├── concerns
+│   │   ├── deck.rb
+│   │   ├── flashcard.rb
+│   │   ├── flashcard_review.rb
+│   │   ├── following.rb
+│   │   ├── goal.rb
+│   │   ├── media_upload.rb
+│   │   ├── notification.rb
+│   │   ├── reaction.rb
+│   │   ├── reflection.rb
+│   │   ├── study_session.rb
+│   │   ├── tag.rb
+│   │   ├── tagging.rb
+│   │   ├── user.rb
+│   │   ├── user_badge.rb
+│   │   ├── user_challenge.rb
+│   │   ├── user_setting.rb
+│   │   └── xp_log.rb
 │   └── views
 │       ├── api
 │       │   └── v1
-│       │       └── example
-│       │           └── index.json.jbuilder
+│       │       ├── dashboard
+│       │       │   └── show.json.jbuilder
+│       │       ├── decks
+│       │       │   ├── _deck.json.jbuilder
+│       │       │   ├── index.json.jbuilder
+│       │       │   └── show.json.jbuilder
+│       │       ├── flashcard_reviews
+│       │       │   ├── _flashcard_review.json.jbuilder
+│       │       │   ├── queue.json.jbuilder
+│       │       │   └── show.json.jbuilder
+│       │       ├── flashcards
+│       │       │   ├── _flashcard.json.jbuilder
+│       │       │   ├── index.json.jbuilder
+│       │       │   └── show.json.jbuilder
+│       │       ├── goals
+│       │       │   ├── _goal.json.jbuilder
+│       │       │   ├── index.json.jbuilder
+│       │       │   └── show.json.jbuilder
+│       │       ├── study_sessions
+│       │       │   ├── _study_session.json.jbuilder
+│       │       │   ├── index.json.jbuilder
+│       │       │   └── show.json.jbuilder
+│       │       └── users
+│       │           └── show.json.jbuilder
 │       └── layouts
 │           ├── mailer.html.erb
 │           └── mailer.text.erb
@@ -52,16 +104,39 @@
 │   │   └── inflections.rb
 │   ├── locales
 │   │   └── en.yml
-│   ├── master.key
 │   ├── puma.rb
 │   ├── routes.rb
 │   └── storage.yml
 ├── config.ru
 ├── db
+│   ├── migrate
+│   │   ├── 20250413021029_create_users.rb
+│   │   ├── 20250413021144_create_goals.rb
+│   │   ├── 20250413021157_create_study_sessions.rb
+│   │   ├── 20250413021205_create_decks.rb
+│   │   ├── 20250413021217_create_flashcards.rb
+│   │   ├── 20250413021222_create_flashcard_reviews.rb
+│   │   ├── 20250413021228_create_notifications.rb
+│   │   ├── 20250413021235_create_user_settings.rb
+│   │   ├── 20250413021241_create_tags.rb
+│   │   ├── 20250413021247_create_taggings.rb
+│   │   ├── 20250413021906_create_followings.rb
+│   │   ├── 20250413033159_create_reactions.rb
+│   │   ├── 20250413033211_create_activity_logs.rb
+│   │   ├── 20250413033251_create_badges.rb
+│   │   ├── 20250413033257_create_user_badges.rb
+│   │   ├── 20250413033304_create_xp_logs.rb
+│   │   ├── 20250413033309_create_reflections.rb
+│   │   ├── 20250413033314_create_comments.rb
+│   │   ├── 20250413033320_create_media_uploads.rb
+│   │   ├── 20250413033326_create_challenges.rb
+│   │   ├── 20250413033336_create_user_challenges.rb
+│   │   └── 20250413033341_create_ai_requests.rb
 │   ├── schema.rb
 │   └── seeds.rb
 ├── lib
 │   └── tasks
+│       └── db.rake
 └── server_tree.txt
 
-24 directories, 40 files
+31 directories, 108 files


### PR DESCRIPTION
### Summary

This PR introduces a **developer-only user switching component** (`UserSwitcher.jsx`) to enable fast login transitions between seeded demo users. This is useful for testing authentication flows, demonstrating app state changes, and simulating multiple user perspectives during development and MVP demos.

---

### Key Changes

#### `UserSwitcher.jsx` (new)

- Added under `components/development/` to isolate the tool from production builds.
    
- Renders buttons for 3 seeded users: Alice, Bob, and Carol.
    
- On click, triggers the login POST request to `/api/v1/login` using valid credentials.
    
- Stores the authenticated user in the Redux `auth` slice.
    
- Displays the current "Logged in as: {username}" for quick dev visibility.
    
- Only renders in `development` mode via `import.meta.env.MODE`.
    

#### `Sidebar.jsx`

- Imported and rendered the `UserSwitcher` component above the Logout button.
    
- Ensures availability across the app during local dev.
    

#### `axios.js`

- Configured axios to:
    
    - Use `import.meta.env.VITE_API_URL` as the base.
        
    - Set `withCredentials: true` for session-based login support.
        
    - Works seamlessly with Rails' CORS config.
        

#### `cors.rb` (Rails)

- Expanded allowed `origins` to include both:
    
    - `http://localhost:5173`
        
    - `http://127.0.0.1:5173`
        
- Ensures compatibility regardless of how the frontend is served.
    
- CORS policy includes `credentials: true` to support secure session cookies.
    

#### Updated tree files:

- `client_tree.txt`: now reflects the `components/development/` directory and its `UserSwitcher.jsx` file.
    
- `server_tree.txt`: no functional changes, but brought current to reflect latest file structure.
    

---

### How to Test

1. Start the backend (`rails s`) and frontend (`npm run dev`) locally.
    
2. Ensure `NODE_ENV=development` is set or `VITE_API_URL` points to your local Rails API.
    
3. Open the app in browser → inspect sidebar.
    
4. Use the **Switch User** buttons to simulate login.
    
5. Confirm that the Redux state updates and shows the correct user as "Logged in as".
    

---

### Notes

- This component does **not** exist in production builds.
    
- Can be expanded later to simulate role-based access, token expiration, or session hijacking.
    
- You may want to refactor the demo credentials into a `.dev-config.js` or similar file down the line.