### PR TITLE
Preload User Decks and Goals on Dashboard + Various Session and Goal Improvements

### DIFF
--- a/client/client_tree.txt
+++ b/client/client_tree.txt
@@ -11,27 +11,34 @@ client
 │   ├── App.jsx
 │   ├── api
 │   │   ├── axios.js
-│   │   └── goalsApi.js
+│   │   ├── goalsApi.js
+│   │   └── studySessionsApi.js
 │   ├── assets
+│   │   ├── flashcards.png
 │   │   ├── logo.png
 │   │   └── work.png
 │   ├── components
 │   │   ├── AnimatedCard.jsx
+│   │   ├── Auth.jsx
 │   │   ├── BackgroundStudy.jsx
 │   │   ├── Button.jsx
 │   │   ├── DeckCard.jsx
 │   │   ├── Flashcard.jsx
 │   │   ├── FlashcardStudy.jsx
+│   │   ├── FlashcardStudyBackup.jsx
 │   │   ├── ForegroundStudy.jsx
+│   │   ├── GoalForm.jsx
+│   │   ├── GoalsList.jsx
 │   │   ├── Input.jsx
 │   │   ├── Layout
 │   │   │   ├── Footer.jsx
-│   │   │   ├── GoalForm.jsx
-│   │   │   ├── GoalsList.jsx
 │   │   │   ├── Header.jsx
 │   │   │   ├── Layout.jsx
 │   │   │   └── Sidebar.jsx
 │   │   ├── PageWrapper.jsx
+│   │   ├── ReviewQueue.jsx
+│   │   ├── StudyHistory.jsx
+│   │   ├── StudySession.jsx
 │   │   ├── TestAuth.jsx
 │   │   ├── Textarea.jsx
 │   │   ├── ToggleSwitch.jsx
@@ -47,6 +54,10 @@ client
 │   │   │   └── flashcardsSlice.js
 │   │   ├── goals
 │   │   │   └── goalsSlice.js
+│   │   ├── review
+│   │   │   └── flashcardReviewSlice.js
+│   │   ├── studySessions
+│   │   │   └── studySessionSlice.js
 │   │   └── user
 │   │       └── userSlice.js
 │   ├── hooks
@@ -67,11 +78,17 @@ client
 │   │   │   └── index.scss
 │   │   ├── components
 │   │   │   ├── _app.scss
+│   │   │   ├── _auth.scss
 │   │   │   ├── _backgroundstudy.scss
 │   │   │   ├── _buttons.scss
 │   │   │   ├── _deckcard.scss
 │   │   │   ├── _flashcardStudy.scss
+│   │   │   ├── _goalform.scss
+│   │   │   ├── _goalslist.scss
 │   │   │   ├── _input.scss
+│   │   │   ├── _reviewqueue.scss
+│   │   │   ├── _studyhistory.scss
+│   │   │   ├── _studysession.scss
 │   │   │   ├── _textarea.scss
 │   │   │   ├── _toggleswitch.scss
 │   │   │   ├── _uishowcase.scss
@@ -93,7 +110,8 @@ client
 │   │       ├── _variables.scss
 │   │       └── index.scss
 │   └── utils
+│       ├── calculateGoalTime.js
 │       └── helpers.js
 └── vite.config.js
 
-22 directories, 74 files
+24 directories, 90 files

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import Layout from "./components/Layout/Layout";
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Dashboard from './pages/Dashboard';
-import Study from './pages/Study';
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import Dashboard from "./pages/Dashboard";
+import Study from "./pages/Study";
 import Decks from "./pages/Decks";
 import GoalsList from "./components/GoalsList";
 import Auth from "./components/Auth";
@@ -12,7 +12,8 @@ function App() {
       <Layout>
         <Routes location={location} key={location.pathname}>
           <Route path="/" element={<Dashboard />} />
-          <Route path="/study/:deckId" element={<Study /> } />
+          <Route path="/study/:deckId" element={<Study />} />
+          <Route path="/study/goal/:goalId" element={<Study />} />
           <Route path="/decks" element={<Decks />} />
           <Route path="/goals" element={<GoalsList />} />
           <Route path="/login" element={<Auth />} />

--- a/client/src/api/goalsApi.js
+++ b/client/src/api/goalsApi.js
@@ -1,8 +1,12 @@
 import axios from "./axios"; // Configured axios instance
 
-// GET all goals
-export const getGoals = async () => {
-  const response = await axios.get("/api/v1/goals"); // Make a GET request to fetch all goals
+// GET all goals, optionally by user ID
+export const getGoals = async (userId = null) => {
+  let url = "/api/v1/goals"; // Make a GET request to fetch all goals
+  if (userId) {
+    url += `?user_id=${userId}`;
+  }
+  const response = await axios.get(url);
   return response.data; // Return the data from the response
 };
 

--- a/client/src/api/goalsApi.js
+++ b/client/src/api/goalsApi.js
@@ -1,11 +1,7 @@
 import axios from "./axios"; // Configured axios instance
 
 // GET all goals, optionally by user ID
-export const getGoals = async (userId = null) => {
-  let url = "/api/v1/goals"; // Make a GET request to fetch all goals
-  if (userId) {
-    url += `?user_id=${userId}`;
-  }
+export const getGoals = async (url = "/api/v1/goals") => {
   const response = await axios.get(url);
   return response.data; // Return the data from the response
 };

--- a/client/src/api/studySessionsApi.js
+++ b/client/src/api/studySessionsApi.js
@@ -4,3 +4,9 @@ export const createStudySession = async (sessionData) => {
   const response = await axios.post("/api/v1/study_sessions", sessionData);
   return response.data;
 };
+
+// fetch all sessions for current user
+export const getStudySessions = async () => {
+  const response = await axios.get("/api/v1/study_sessions");
+  return response.data;
+};

--- a/client/src/api/studySessionsApi.js
+++ b/client/src/api/studySessionsApi.js
@@ -1,0 +1,6 @@
+import axios from "./axios"; // your configured axios
+
+export const createStudySession = async (sessionData) => {
+  const response = await axios.post("/api/v1/study_sessions", sessionData);
+  return response.data;
+};

--- a/client/src/components/BackgroundStudy.jsx
+++ b/client/src/components/BackgroundStudy.jsx
@@ -12,14 +12,12 @@ const BackgroundStudy = ({ deckId, goalId }) => {
   const deck = decks.find((d) => d.id === Number(deckId));
   const goal = goals.find((g) => g.id === Number(goalId));
 
-  // Fetch decks if needed
   useEffect(() => {
     if (decksStatus === "idle") {
       dispatch(fetchDecks());
     }
   }, [dispatch, decksStatus]);
 
-  // Fetch goals if needed
   useEffect(() => {
     if (goals.length === 0 && !goalsLoading) {
       dispatch(fetchGoals());

--- a/client/src/components/BackgroundStudy.jsx
+++ b/client/src/components/BackgroundStudy.jsx
@@ -1,35 +1,37 @@
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
-import { fetchDecks } from '../features/decks/decksSlice';
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchDecks } from "../features/decks/decksSlice";
+import { fetchGoals } from "../features/goals/goalsSlice";
 
-const BackgroundStudy = () => {
-  const { deckId } = useParams();
+const BackgroundStudy = ({ deckId, goalId }) => {
   const dispatch = useDispatch();
 
-  const { decks, status } = useSelector(state => state.decks);
-  const deck = decks.find(d => d.id === Number(deckId));
+  const { decks, status: decksStatus } = useSelector((state) => state.decks);
+  const { goals, loading: goalsLoading } = useSelector((state) => state.goals);
 
-  // Fetch decks
+  const deck = decks.find((d) => d.id === Number(deckId));
+  const goal = goals.find((g) => g.id === Number(goalId));
 
+  // Fetch decks if needed
   useEffect(() => {
-    if (status === 'idle') {
+    if (decksStatus === "idle") {
       dispatch(fetchDecks());
     }
-  }, [dispatch, status]);
-  
+  }, [dispatch, decksStatus]);
+
+  // Fetch goals if needed
+  useEffect(() => {
+    if (goals.length === 0 && !goalsLoading) {
+      dispatch(fetchGoals());
+    }
+  }, [dispatch, goals.length, goalsLoading]);
+
+  const title = goal ? goal.title : deck ? deck.title : "Study Session";
+
   return (
-    <>
-      <div className='background-study'>
-        <h2>
-        {status === 'loading'
-          ? 'Loading...'
-          : deck
-          ? deck.title
-          : 'Deck not found'}
-        </h2>
-      </div> 
-    </>
+    <div className="background-study">
+      <h2>{title}</h2>
+    </div>
   );
 };
 

--- a/client/src/components/DeckCard.jsx
+++ b/client/src/components/DeckCard.jsx
@@ -1,46 +1,46 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import Flashcards from './Flashcard';
-import Button from './Button';
-import Input from './Input';
-import Textarea from './Textarea';
-import ToggleSwitch from './ToggleSwitch';
-import AnimatedCard from './AnimatedCard';
+import React from "react";
+import { Link } from "react-router-dom";
+import Flashcards from "./Flashcard";
+import Button from "./Button";
+import Input from "./Input";
+import Textarea from "./Textarea";
+import ToggleSwitch from "./ToggleSwitch";
+import AnimatedCard from "./AnimatedCard";
 import { AnimatePresence } from "framer-motion";
-import { CircleX, SquarePen, Trash2 } from 'lucide-react'; 
-import useIsMobile from '../hooks/useIsMobile';
+import { CircleX, SquarePen, Trash2 } from "lucide-react";
+import useIsMobile from "../hooks/useIsMobile";
 
 // DeckCard component displays a deck and conditionally allows editing
 const DeckCard = ({
-  deck,                 
+  deck,
   editingDeckId,
   editForm,
   setEditForm,
   setEditingDeckId,
   handleUpdate,
   handleDelete,
-  handleEditClick
+  handleEditClick,
 }) => {
   const isEditing = editingDeckId === deck.id; // check if this deck is being edited
 
   const isMobile = useIsMobile(768);
   return (
     <>
-      <div className='deck-wrapper'>
+      <div className="deck-wrapper">
         {/* Main deck card display */}
         <div className="deck-card">
           <h3>{deck.title}</h3>
           <p>{deck.description}</p>
 
           {/* Mobile-only button row for Study and Edit/Delete */}
-          <div className='mobile-btn-row'>
-            <Button variant={`${isMobile ? 'secondary-reverse' : 'primary'}`}>
+          <div className="mobile-btn-row">
+            <Button variant={`${isMobile ? "secondary-reverse" : "primary"}`}>
               <Link to={`/study/${deck.id}`}>Study</Link>
             </Button>
 
             <div className="edit-overlay">
-              <SquarePen onClick={() => handleEditClick(deck)} />  
-              <Trash2 onClick={() => handleDelete(deck.id)} />     
+              <SquarePen onClick={() => handleEditClick(deck)} />
+              <Trash2 onClick={() => handleDelete(deck.id)} />
             </div>
           </div>
 
@@ -51,11 +51,11 @@ const DeckCard = ({
 
         {/* Section below the deck for flashcards or edit form */}
         <div className="flashcards-wrapper">
-
           {/* Show Edit Form if in edit mode */}
-          <AnimatePresence mode="wait">   
-            {isEditing && 
-              <AnimatedCard className='deck-edit'
+          <AnimatePresence mode="wait">
+            {isEditing && (
+              <AnimatedCard
+                className="deck-edit"
                 key="decks"
                 initial={{ opacity: 0, x: -30 }}
                 animate={{ opacity: 1, x: 0 }}
@@ -67,7 +67,9 @@ const DeckCard = ({
                   type="text"
                   value={editForm.title}
                   label="Title"
-                  onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
+                  onChange={(e) =>
+                    setEditForm({ ...editForm, title: e.target.value })
+                  }
                   placeholder="Title"
                 />
 
@@ -76,30 +78,37 @@ const DeckCard = ({
                   value={editForm.description}
                   rows={2}
                   label="Description"
-                  onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
+                  onChange={(e) =>
+                    setEditForm({ ...editForm, description: e.target.value })
+                  }
                   placeholder="Description"
                 />
 
                 {/* Public/Private Toggle */}
-                <ToggleSwitch 
-                  isPublic={editForm.is_public}  
+                <ToggleSwitch
+                  isPublic={editForm.is_public}
                   onChange={(newVal) =>
                     setEditForm({ ...editForm, is_public: newVal })
-                  } 
+                  }
                 />
 
                 {/* Save/Cancel Buttons */}
-                <div className="btn-row">  
+                <div className="btn-row">
                   <Button onClick={handleUpdate}>Save</Button>
-                  <Button variant='secondary' onClick={() => setEditingDeckId(null)}>Cancel</Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setEditingDeckId(null)}
+                  >
+                    Cancel
+                  </Button>
                 </div>
-              </AnimatedCard> 
-            }
+              </AnimatedCard>
+            )}
           </AnimatePresence>
 
           {/* Show Flashcards if NOT in edit mode */}
           <AnimatePresence mode="wait">
-            {!isEditing && 
+            {!isEditing && (
               <AnimatedCard
                 key="flashcards"
                 initial={{ opacity: 0, x: 50 }}
@@ -109,9 +118,9 @@ const DeckCard = ({
               >
                 <Flashcards deckId={deck.id} />
               </AnimatedCard>
-            }       
-          </AnimatePresence> 
-        </div> 
+            )}
+          </AnimatePresence>
+        </div>
       </div>
     </>
   );

--- a/client/src/components/ForegroundStudy.jsx
+++ b/client/src/components/ForegroundStudy.jsx
@@ -1,107 +1,83 @@
-import { useEffect, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
-import StudySession from '../components/StudySession';
-import { fetchFlashcards } from '../features/flashcards/flashcardsSlice';
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchFlashcards } from "../features/flashcards/flashcardsSlice";
 import { Link } from "react-router-dom";
-import { ArrowLeft } from 'lucide-react';
-import FlashcardStudy from '../components/FlashcardStudy';
+import { ArrowLeft } from "lucide-react";
+import FlashcardStudy from "./FlashcardStudy";
 import { motion } from "framer-motion";
 
-
-const ForegroundStudy = () => {
+const ForegroundStudy = ({ deckId }) => {
+  const dispatch = useDispatch();
   const session = useSelector((state) => state.studySession);
 
   const [flippedCards, setFlippedCards] = useState({});
-  const handleFlip = (id) => {
-    setFlippedCards(prev => ({
-      ...prev,
-      [id]: !prev[id] 
-    }));
-  };
   const [expandedCardId, setExpandedCardId] = useState(null);
 
-  const handleExpand = (id) => {
-    setExpandedCardId(prev => {
-      // if collapsing, unflip the card too
-      if (prev === id) {
-        setFlippedCards(flips => ({
-          ...flips,
-          [id]: false,
-        }));
-        return null; // collapse
-      }
-      return id; // expand
-    });
-  };
-
-  const ref = useRef(null);
-  const { deckId } = useParams();
-  const dispatch = useDispatch();
-
-  // Select flashcards, status, and error from Redux store for the current deck
-  const flashcardData = useSelector((state) => state.flashcards.byDeckId[deckId]);
+  const flashcardData = useSelector(
+    (state) => state.flashcards.byDeckId[deckId]
+  );
   const flashcards = flashcardData?.flashcards || [];
- //  const isLoading = flashcardData?.status === 'loading';
-  const isLoading = !flashcardData || flashcardData.status === 'loading';
-  const error = flashcardData?.error;
-
-  // Fetch flashcards
+  const isLoading = !flashcardData || flashcardData.status === "loading";
 
   useEffect(() => {
     if (deckId) {
-      console.log('Fetching flashcards for deck:', deckId);
+      console.log("Fetching flashcards for deck:", deckId);
       dispatch(fetchFlashcards(deckId));
     }
   }, [deckId, dispatch]);
-  
+
   const isSessionActive = session.startTime && !session.endTime;
 
   return (
-    <div className='foreground-study'>
-      { session.endTime && <Link className='flex align-items-center gap10 mb1' to="/decks"><ArrowLeft /> Decks</Link>}
-      <StudySession deckId={deckId} />
-      {/* Conditionally render flashcards once the session has started */}
+    <div className="foreground-study">
+      {session.endTime && (
+        <Link className="flex align-items-center gap10 mb1" to="/decks">
+          <ArrowLeft /> Back
+        </Link>
+      )}
       {isSessionActive && (
         <div>
-          { isLoading ?  (
-            <p className='no-flashcards'> </p>
+          {isLoading ? (
+            <p className="no-flashcards"></p>
+          ) : flashcards.length > 0 ? (
+            <div className="flashcards-study">
+              {flashcards.map((card) => (
+                <FlashcardStudy
+                  key={card.id}
+                  flashcard_id={card.id}
+                  front_text={card.front_text}
+                  back_text={card.back_text}
+                  isFlip={!!flippedCards[card.id]}
+                  isExpand={expandedCardId === card.id}
+                  onClick={() =>
+                    setFlippedCards((prev) => ({
+                      ...prev,
+                      [card.id]: !prev[card.id],
+                    }))
+                  }
+                  onExpand={() =>
+                    setExpandedCardId((prev) =>
+                      prev === card.id ? null : card.id
+                    )
+                  }
+                />
+              ))}
+            </div>
           ) : (
-            flashcards.length > 0 ? (
-              <div className='flashcards-study' ref={ref}> 
-                {flashcards.map(card => (
-                  <FlashcardStudy key={card.id}    
-                    reference={ref}    
-                    flashcard_id={card.id}         
-                    front_text={card.front_text}
-                    back_text={card.back_text}
-                    isFlip={!!flippedCards[card.id]}
-                    isExpand={expandedCardId === card.id}
-                    onClick={() => handleFlip(card.id)}
-                    onExpand={() => handleExpand(card.id)}
-                  />
-                ))}
-              </div>
-            ) : (
-              <p className='no-flashcards'>No flashcards found for this deck.</p>
-            )
-          )} 
-
-          {expandedCardId && (
-            <motion.div 
-              className="backdrop" 
-              initial={{ opacity: 0 }} 
-              animate={{ opacity: 1 }} 
-              exit={{ opacity: 0 }} 
-              transition={{ duration: 0.3 }}
-              onClick={() => setExpandedCardId(null)} // Optional: click backdrop to close
-            />
+            <p className="no-flashcards">No flashcards found.</p>
           )}
         </div>
       )}
-
-
-
+      {expandedCardId && (
+        <motion.div
+          className="backdrop"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          onClick={() => setExpandedCardId(null)}
+        />
+      )}
     </div>
   );
 };

--- a/client/src/components/ForegroundStudy.jsx
+++ b/client/src/components/ForegroundStudy.jsx
@@ -6,7 +6,7 @@ import { ArrowLeft } from "lucide-react";
 import FlashcardStudy from "./FlashcardStudy";
 import { motion } from "framer-motion";
 
-const ForegroundStudy = ({ deckId }) => {
+const ForegroundStudy = ({ deckId, goalId }) => {
   const dispatch = useDispatch();
   const session = useSelector((state) => state.studySession);
 

--- a/client/src/components/GoalsList.jsx
+++ b/client/src/components/GoalsList.jsx
@@ -8,6 +8,7 @@ import { CirclePlus, CircleX, SquarePen, Trash2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion"; // Import motion and AnimatePresence for animations
 import { calculateGoalTime } from "../utils/calculateGoalTime"; // Utility function to calculate goal time
 import "../styles/components/_goalslist.scss"; // Import styles for the GoalsList component
+import { useNavigate } from "react-router-dom";
 
 const GoalsList = () => {
   const {
@@ -20,6 +21,7 @@ const GoalsList = () => {
     removeGoal,
   } = useGoals(); // Custom hook to manage goals
 
+  const navigate = useNavigate();
   const [formVisible, setFormVisible] = useState(false); // State to manage the visibility of the form
   const [editingGoal, setEditingGoal] = useState(null); // State to manage the goal being edited
   const authUser = useSelector((state) => state.auth.user); // Grab logged in user
@@ -152,6 +154,12 @@ const GoalsList = () => {
                 {/* Extra delete icon for non-mobile usage */}
                 <CircleX onClick={() => removeGoal(goal.id)} />
                 <div className="edit-overlay">
+                  <Button
+                    variant="primary"
+                    onClick={() => navigate(`/study/goal/${goal.id}`)}
+                  >
+                    Study Goal
+                  </Button>
                   <SquarePen onClick={() => handleEditClick(goal)} />
                   <Trash2 onClick={() => removeGoal(goal.id)} />
                 </div>

--- a/client/src/components/GoalsList.jsx
+++ b/client/src/components/GoalsList.jsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from "react";
 import useGoals from "../hooks/useGoals";
+import { useSelector } from "react-redux"; // Import useSelector to access Redux store
 import GoalForm from "./GoalForm";
 import Button from "./Button";
 import AnimatedCard from "./AnimatedCard";
-import { CirclePlus, CircleX, SquarePen, Trash2} from "lucide-react";
+import { CirclePlus, CircleX, SquarePen, Trash2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion"; // Import motion and AnimatePresence for animations
 import { calculateGoalTime } from "../utils/calculateGoalTime"; // Utility function to calculate goal time
-import { useSelector, useDispatch } from "react-redux"; // Import useSelector to access Redux store
-
 import "../styles/components/_goalslist.scss"; // Import styles for the GoalsList component
 
 const GoalsList = () => {
@@ -20,24 +19,26 @@ const GoalsList = () => {
     updateExistingGoal,
     removeGoal,
   } = useGoals(); // Custom hook to manage goals
-  
+
   const [formVisible, setFormVisible] = useState(false); // State to manage the visibility of the form
   const [editingGoal, setEditingGoal] = useState(null); // State to manage the goal being edited
+  const authUser = useSelector((state) => state.auth.user); // Grab logged in user
+  const sessionHistory = useSelector(
+    (state) => state.studySession.sessionHistory
+  ); // Fetch session history from Redux store
 
-  // Fetch session history from Redux store
-  const sessionHistory = useSelector((state) => state.studySession.sessionHistory);
+  // Log session history to check goalId
+  useEffect(() => {
+    // console.log("Session history:", sessionHistory);
+  }, [sessionHistory]);
 
-// Log session history to check goalId
-useEffect(() => {
-  console.log("Session history:", sessionHistory);
-}, [sessionHistory]);
-
-  const goalId = useSelector(state => state.studySession.goalId); // Fetch the goalId from the state
+  const goalId = useSelector((state) => state.studySession.goalId); // Fetch the goalId from the state
 
   // Load all goals when the component renders
   useEffect(() => {
-    loadAllGoals(); // Fetch all goals from the API
-  }, []);
+    const userId = authUser?.id || null;
+    loadAllGoals(userId); // <-- Pass userId into loadAllGoals
+  }, [authUser]);
 
   // Handle clicking the Edit button
   const handleEditClick = (goal) => {
@@ -95,12 +96,22 @@ useEffect(() => {
 
       {/* Render loading or error messages */}
       {loading && (
-        <AnimatedCard key="loading" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
+        <AnimatedCard
+          key="loading"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+        >
           <p>Loading goals...</p>
         </AnimatedCard>
       )}
       {error && (
-        <AnimatedCard key="error" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
+        <AnimatedCard
+          key="error"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+        >
           <p>Error loading goals: {error}</p>
         </AnimatedCard>
       )}
@@ -111,36 +122,46 @@ useEffect(() => {
       ) : (
         <ul className="goal-wrapper">
           {goals.map((goal) => {
-            console.log("Goal being processed:", goal); // Log the goal to check its id
+            // console.log("Goal being processed:", goal); // Log the goal to check its id
             // Calculate the total time spent on each goal using the utility function
             const totalTimeSpent = calculateGoalTime(sessionHistory, goal.id);
-            const progress = goal.target_hours > 0
-              ? Math.min(((totalTimeSpent / (goal.target_hours * 60)) * 100), 100)
-              : 0;// Converts traget_hours to minutes then multiply by 100 to get percentage, caps at 100%
+            const progress =
+              goal.target_hours > 0
+                ? Math.min(
+                    (totalTimeSpent / (goal.target_hours * 60)) * 100,
+                    100
+                  )
+                : 0; // Converts traget_hours to minutes then multiply by 100 to get percentage, caps at 100%
             return (
-            <li key={goal.id} className="goal-card">
-             <div>
-              <h3>{goal.title}</h3>
-              <p>{goal.description}</p>
-             </div>
-              <span className="finish-by">Finish by: <b>{goal.target_hours} minutes</b></span>
-              <div className="progress-bar">
-                <progress className={`${progress > 50 ? '' : 'less-half'}`} value={progress} max="100"></progress>
-                <p>{Math.round(progress)}%</p>
-              </div>
-              {/* Extra delete icon for non-mobile usage */}
-              <CircleX onClick={() => removeGoal(goal.id)} />
-              <div className="edit-overlay">
-                <SquarePen onClick={() => handleEditClick(goal)} />  
-                <Trash2 onClick={() => removeGoal(goal.id)} />     
-              </div>
-            </li>
-            )
+              <li key={goal.id} className="goal-card">
+                <div>
+                  <h3>{goal.title}</h3>
+                  <p>{goal.description}</p>
+                </div>
+                <span className="finish-by">
+                  Finish by: <b>{goal.target_hours} minutes</b>
+                </span>
+                <div className="progress-bar">
+                  <progress
+                    className={`${progress > 50 ? "" : "less-half"}`}
+                    value={progress}
+                    max="100"
+                  ></progress>
+                  <p>{Math.round(progress)}%</p>
+                </div>
+                {/* Extra delete icon for non-mobile usage */}
+                <CircleX onClick={() => removeGoal(goal.id)} />
+                <div className="edit-overlay">
+                  <SquarePen onClick={() => handleEditClick(goal)} />
+                  <Trash2 onClick={() => removeGoal(goal.id)} />
+                </div>
+              </li>
+            );
           })}
         </ul>
       )}
     </div>
-  )
-}
+  );
+};
 
 export default GoalsList;

--- a/client/src/components/StudyHistory.jsx
+++ b/client/src/components/StudyHistory.jsx
@@ -1,18 +1,31 @@
+import { useSelector } from "react-redux";
+
 const StudyHistory = ({ sessionHistory }) => {
+  const decks = useSelector((state) => state.decks.decks);
+  const goals = useSelector((state) => state.goals.goals);
+
+  const findDeckTitleFromGoal = (goalId) => {
+    const goal = goals.find((g) => g.id === goalId);
+    if (!goal) return "Unknown Goal";
+
+    const deck = decks.find((d) => d.id === goal.deck_id);
+    return deck ? deck.title : "Unknown Deck";
+  };
+
   return (
-    <div className='study-history'>
+    <div className="study-history">
       {sessionHistory.length > 0 ? (
         <ul className="space-y-2">
           {sessionHistory.map((sesh, index) => (
             <li key={index} className="p-4 bg-gray-100 rounded-md shadow-md">
               <div>
-                <strong>Deck:</strong> {sesh.deckId || 'N/A'}
+                <strong>Deck:</strong> {findDeckTitleFromGoal(sesh.goal_id)}
               </div>
               <div>
-                <strong>Duration:</strong> {sesh.durationMin} min
+                <strong>Duration:</strong> {sesh.duration_min || 0} min
               </div>
               <div>
-                <strong>Notes:</strong> {sesh.notes || 'None'}
+                <strong>Notes:</strong> {sesh.notes || "None"}
               </div>
             </li>
           ))}

--- a/client/src/components/StudySession.jsx
+++ b/client/src/components/StudySession.jsx
@@ -1,104 +1,143 @@
+// React + Redux imports
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+
+// Import session-related actions from Redux slice
 import {
   startSession,
   endSession,
   addNotes,
   resetSession,
   logSession,
+  submitStudySession,
 } from "../features/studySessions/studySessionSlice";
-import { submitStudySession } from "../features/studySessions/studySessionSlice";
+
+// UI and animations
 import { CirclePlus, CircleX } from "lucide-react";
 import Button from "./Button";
 import Textarea from "./Textarea";
 import { motion } from "framer-motion";
 
+// Main StudySession component
 const StudySession = ({ deckId, goalId }) => {
-  // <-- accept both
   const dispatch = useDispatch();
+
+  // Get current study session state
   const session = useSelector((state) => state.studySession);
-  const authUser = useSelector((state) => state.auth.user); // Get logged in user
+
+  // Get logged-in user (needed for saving a session)
+  const authUser = useSelector((state) => state.auth.user);
+
+  // Local state for note input and modal toggle
   const [noteInput, setNoteInput] = useState("");
   const [isNote, setIsNote] = useState(false);
+
+  // Local state to track session start timestamp (for manual duration calculation)
   const [startTimestamp, setStartTimestamp] = useState(null);
 
+  // 🚨 BAD: This nukes the session **every time the component mounts**!
+  // 🚫 REMOVE THIS useEffect immediately:
+  /*
+  useEffect(() => {
+    dispatch(resetSession());
+  }, [dispatch]);
+  */
+
+  // ✅ Correct initialization: Start a session once the deckId (and optionally goalId) are known
+  useEffect(() => {
+    if (deckId) {
+      console.log(
+        "Initializing session with deckId:",
+        deckId,
+        "and goalId:",
+        goalId
+      );
+      dispatch(startSession({ deckId, goalId }));
+    }
+  }, [deckId, goalId, dispatch]);
+
+  // Debugging - optional, to track session changes
   useEffect(() => {
     console.log("Current session state:", session);
   }, [session]);
 
-  useEffect(() => {
-    if (session?.startTime || session?.deckId) {
-      console.log("Resetting session state on mount...");
-      dispatch(resetSession());
-    }
-  }, []);
-
+  // Handler to manually start session if needed (usually not triggered because auto-start happens)
   const handleStart = () => {
-    console.log("Start clicked. Deck ID:", deckId, "Goal ID:", goalId);
-    dispatch(startSession({ deckId, goalId })); // <-- both deck and goal
+    console.log("Manual Start clicked. Deck ID:", deckId, "Goal ID:", goalId);
+    dispatch(startSession({ deckId, goalId }));
     setStartTimestamp(Date.now());
   };
 
+  // Handler to manually end session
   const handleEnd = () => {
-    if (!startTimestamp) return;
+    if (!startTimestamp) return; // Prevent ending if session never started
 
     const end = Date.now();
     const duration = Math.floor((end - startTimestamp) / 60000);
+
     dispatch(endSession({ endTime: end, duration }));
     dispatch(logSession());
 
-    // Submit to server
-    const {
-      deckId: currentDeckId,
-      goalId: currentGoalId,
-      durationMin,
-      notes,
-    } = session;
-    if (durationMin > 0 && currentGoalId) {
+    // Submit session to server if this session is tied to a goal
+    if (duration > 0 && goalId) {
       dispatch(
         submitStudySession({
           user_id: authUser?.id,
-          goal_id: currentGoalId,
-          duration_min: durationMin,
-          notes: notes || "",
+          goal_id: goalId,
+          duration_min: duration,
+          notes: session.notes || "",
         })
       );
     }
+
+    // Clear local timestamp
     setStartTimestamp(null);
 
+    // Schedule full reset AFTER a delay, so user sees summary (120 seconds)
     setTimeout(() => dispatch(resetSession()), 120000);
   };
 
+  // Track textarea input for session notes
   const handleNoteChange = (e) => {
     setNoteInput(e.target.value);
   };
 
+  // Submit notes to Redux state
   const handleNoteSubmit = () => {
     dispatch(addNotes(noteInput));
     setNoteInput("");
     setIsNote(false);
   };
 
+  // Toggle add-note modal open/close
   const handleNotes = () => {
     setIsNote((prev) => !prev);
   };
 
+  // Determine if a session is actively running (started but not ended)
   const isSessionActive = session.startTime && !session.endTime;
 
   return (
     <div
       className={`${!session.startTime ? "start-session" : "study-session"}`}
     >
+      {/* 
+        Display "Start Session" button if no session is active.
+        Otherwise show the active session UI.
+      */}
       {!session.startTime ? (
         <Button variant="primary" onClick={handleStart}>
           Start Study Session
         </Button>
       ) : isSessionActive ? (
         <>
+          {/* Show session start time */}
           <p className="running-session">
             Session started at:{" "}
             {new Date(session.startTime).toLocaleTimeString()}
           </p>
+
+          {/* Button to add notes */}
           <Button
             variant="primary"
             className="btn-add-notes"
@@ -106,6 +145,8 @@ const StudySession = ({ deckId, goalId }) => {
           >
             Add Notes <CirclePlus />
           </Button>
+
+          {/* Notes modal */}
           {isNote && (
             <div className="notes-modal">
               <Textarea
@@ -118,6 +159,8 @@ const StudySession = ({ deckId, goalId }) => {
               <CircleX onClick={handleNotes} />
             </div>
           )}
+
+          {/* End Session button */}
           <Button
             variant="primary"
             className="btn-end-session"
@@ -128,6 +171,18 @@ const StudySession = ({ deckId, goalId }) => {
         </>
       ) : (
         ""
+      )}
+
+      {/* Animate background blur if notes modal open */}
+      {isNote && (
+        <motion.div
+          className="backdrop"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          onClick={() => setIsNote(false)}
+        />
       )}
     </div>
   );

--- a/client/src/components/StudySession.jsx
+++ b/client/src/components/StudySession.jsx
@@ -1,36 +1,41 @@
-import { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
-import { startSession, endSession, addNotes, resetSession, logSession } from '../features/studySessions/studySessionSlice';
-import { CirclePlus, CircleX} from "lucide-react";
-import Button from './Button';
-import Textarea from './Textarea';
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  startSession,
+  endSession,
+  addNotes,
+  resetSession,
+  logSession,
+} from "../features/studySessions/studySessionSlice";
+import { submitStudySession } from "../features/studySessions/studySessionSlice";
+import { CirclePlus, CircleX } from "lucide-react";
+import Button from "./Button";
+import Textarea from "./Textarea";
 import { motion } from "framer-motion";
 
-const StudySession = () => {
+const StudySession = ({ deckId, goalId }) => {
+  // <-- accept both
   const dispatch = useDispatch();
-  const { deckId } = useParams();
   const session = useSelector((state) => state.studySession);
-  const [noteInput, setNoteInput] = useState('');
+  const authUser = useSelector((state) => state.auth.user); // Get logged in user
+  const [noteInput, setNoteInput] = useState("");
   const [isNote, setIsNote] = useState(false);
   const [startTimestamp, setStartTimestamp] = useState(null);
 
-//debug log session state when it updates
-useEffect(() => {
-  console.log("Current session state:", session);
-}, [session]);
+  useEffect(() => {
+    console.log("Current session state:", session);
+  }, [session]);
 
-useEffect(() => {
-  if (session?.startTime || session?.deckId) {
-    console.log("Resetting session state on mount...");
-    dispatch({ type: 'studySession/resetSession' });
-  }
-}, []);
-
+  useEffect(() => {
+    if (session?.startTime || session?.deckId) {
+      console.log("Resetting session state on mount...");
+      dispatch(resetSession());
+    }
+  }, []);
 
   const handleStart = () => {
-    console.log("Start clicked. Deck ID:", deckId);
-    dispatch(startSession({ deckId }));
+    console.log("Start clicked. Deck ID:", deckId, "Goal ID:", goalId);
+    dispatch(startSession({ deckId, goalId })); // <-- both deck and goal
     setStartTimestamp(Date.now());
   };
 
@@ -38,12 +43,29 @@ useEffect(() => {
     if (!startTimestamp) return;
 
     const end = Date.now();
-    const duration = Math.floor((end - startTimestamp) / 60000)
+    const duration = Math.floor((end - startTimestamp) / 60000);
     dispatch(endSession({ endTime: end, duration }));
     dispatch(logSession());
+
+    // Submit to server
+    const {
+      deckId: currentDeckId,
+      goalId: currentGoalId,
+      durationMin,
+      notes,
+    } = session;
+    if (durationMin > 0 && currentGoalId) {
+      dispatch(
+        submitStudySession({
+          user_id: authUser?.id,
+          goal_id: currentGoalId,
+          duration_min: durationMin,
+          notes: notes || "",
+        })
+      );
+    }
     setStartTimestamp(null);
 
-    //resetting session after 2 minutes so user can see time of study after 2 minutes
     setTimeout(() => dispatch(resetSession()), 120000);
   };
 
@@ -53,68 +75,60 @@ useEffect(() => {
 
   const handleNoteSubmit = () => {
     dispatch(addNotes(noteInput));
-    setNoteInput('');
+    setNoteInput("");
     setIsNote(false);
   };
 
   const handleNotes = () => {
-    setIsNote(prev => !prev);
+    setIsNote((prev) => !prev);
   };
 
-  
   const isSessionActive = session.startTime && !session.endTime;
 
   return (
-    <div className={`${!session.startTime ? 'start-session' : 'study-session' }`}>
+    <div
+      className={`${!session.startTime ? "start-session" : "study-session"}`}
+    >
       {!session.startTime ? (
-        <Button variant='primary' onClick={handleStart}>Start Study Session</Button>
-      ) :  isSessionActive ? (
+        <Button variant="primary" onClick={handleStart}>
+          Start Study Session
+        </Button>
+      ) : isSessionActive ? (
         <>
-          <p className='running-session'>Session started at: {new Date(session.startTime).toLocaleTimeString()}</p>
-          <Button variant='primary' className='btn-add-notes' onClick={handleNotes}>Add Notes <CirclePlus /></Button>
-          {
-            isNote && 
-            <div className='notes-modal'>
+          <p className="running-session">
+            Session started at:{" "}
+            {new Date(session.startTime).toLocaleTimeString()}
+          </p>
+          <Button
+            variant="primary"
+            className="btn-add-notes"
+            onClick={handleNotes}
+          >
+            Add Notes <CirclePlus />
+          </Button>
+          {isNote && (
+            <div className="notes-modal">
               <Textarea
-                value={noteInput} label='Notes'
+                value={noteInput}
+                label="Notes"
                 onChange={handleNoteChange}
                 placeholder="Add notes..."
               />
               <Button onClick={handleNoteSubmit}>Save Notes</Button>
               <CircleX onClick={handleNotes} />
             </div>
-          }
-          <Button variant='primary' className='btn-end-session' onClick={handleEnd}>End Study Session</Button>          
-        </>
-      ) : '' }
-      {session.endTime && session.durationMin !== null && (
-         <p className='session-lasted'>Session lasted {session.durationMin} minute{session.durationMin !== 1 ? 's' : ''}</p>
-      )}
-    
-    {/*Display session history for verification */}
-    { session.sessionHistory.length > 0 && (
-        <div>
-          <h3>Session History:</h3>
-          <ul>
-            {session.sessionHistory.map((sesh, index) => (
-              <li key={index}>
-                Deck: {sesh.deckId || 'N/A'} | Duration: {sesh.durationMin} min | Notes: {sesh.notes || 'None'}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-        {isNote && (
-            <motion.div 
-              className="backdrop" 
-              initial={{ opacity: 0 }} 
-              animate={{ opacity: 1 }} 
-              exit={{ opacity: 0 }} 
-              transition={{ duration: 0.3 }}
-              onClick={() => handleNotes(false)}
-            />
           )}
+          <Button
+            variant="primary"
+            className="btn-end-session"
+            onClick={handleEnd}
+          >
+            End Study Session
+          </Button>
+        </>
+      ) : (
+        ""
+      )}
     </div>
   );
 };

--- a/client/src/features/decks/decksSlice.js
+++ b/client/src/features/decks/decksSlice.js
@@ -1,7 +1,8 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "axios";
 
-// updated to accept optional userId
+// Async thunks
+
 export const fetchDecks = createAsyncThunk(
   "decks/fetchDecks",
   async (userId = null) => {
@@ -35,13 +36,14 @@ export const deleteDeck = createAsyncThunk("decks/deleteDeck", async (id) => {
   return id;
 });
 
-// initial state of the decks slice
+// Initial state
 const initialState = {
-  decks: [], // list of decks
+  decks: [],
   status: "idle",
   error: null,
 };
 
+// Slice
 const decksSlice = createSlice({
   name: "decks",
   initialState,
@@ -68,7 +70,9 @@ const decksSlice = createSlice({
       .addCase(updateDeck.fulfilled, (state, action) => {
         const updated = action.payload;
         const index = state.decks.findIndex((deck) => deck.id === updated.id);
-        if (index !== -1) state.decks[index] = updated;
+        if (index !== -1) {
+          state.decks[index] = updated;
+        }
       })
       // Delete
       .addCase(deleteDeck.fulfilled, (state, action) => {
@@ -77,4 +81,5 @@ const decksSlice = createSlice({
   },
 });
 
+// Exports
 export default decksSlice.reducer;

--- a/client/src/features/decks/decksSlice.js
+++ b/client/src/features/decks/decksSlice.js
@@ -1,30 +1,44 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
-import axios from 'axios'
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
 
-export const fetchDecks = createAsyncThunk('decks/fetchDecks', async () => {
-  const res = await axios.get('/api/v1/decks')
-  return res.data
-})
+// updated to accept optional userId
+export const fetchDecks = createAsyncThunk(
+  "decks/fetchDecks",
+  async (userId = null) => {
+    let url = "/api/v1/decks";
+    if (userId) {
+      url += `?user_id=${userId}`;
+    }
+    const res = await axios.get(url);
+    return res.data;
+  }
+);
 
-export const createDeck = createAsyncThunk('decks/createDeck', async (deckData) => {
-  const res = await axios.post('/api/v1/decks', { deck: deckData })
-  return res.data
-})
+export const createDeck = createAsyncThunk(
+  "decks/createDeck",
+  async (deckData) => {
+    const res = await axios.post("/api/v1/decks", { deck: deckData });
+    return res.data;
+  }
+);
 
-export const updateDeck = createAsyncThunk('decks/updateDeck', async ({ id, updates }) => {
-  const res = await axios.patch(`/api/v1/decks/${id}`, { deck: updates })
-  return res.data
-})
+export const updateDeck = createAsyncThunk(
+  "decks/updateDeck",
+  async ({ id, updates }) => {
+    const res = await axios.patch(`/api/v1/decks/${id}`, { deck: updates });
+    return res.data;
+  }
+);
 
-export const deleteDeck = createAsyncThunk('decks/deleteDeck', async (id) => {
-  await axios.delete(`/api/v1/decks/${id}`)
-  return id
-})
+export const deleteDeck = createAsyncThunk("decks/deleteDeck", async (id) => {
+  await axios.delete(`/api/v1/decks/${id}`);
+  return id;
+});
 
 // initial state of the decks slice
 const initialState = {
   decks: [], // list of decks
-  status: 'idle',
+  status: "idle",
   error: null,
 };
 
@@ -34,33 +48,33 @@ const decksSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
-    // Fetch
-    .addCase(fetchDecks.pending, (state) => {
-      state.status = 'loading'
-    })
-    .addCase(fetchDecks.fulfilled, (state, action) => {
-      state.status = 'succeeded'
-      state.decks = action.payload
-    })
-    .addCase(fetchDecks.rejected, (state, action) => {
-      state.status = 'failed'
-      state.error = action.error.message
-    })
-    // Create
-    .addCase(createDeck.fulfilled, (state, action) => {
-      state.decks.push(action.payload)
-    })
-    // Update
-    .addCase(updateDeck.fulfilled, (state, action) => {
-      const updated = action.payload
-      const index = state.decks.findIndex(deck => deck.id === updated.id)
-      if (index !== -1) state.decks[index] = updated
-    })
-    // Delete
-    .addCase(deleteDeck.fulfilled, (state, action) => {
-      state.decks = state.decks.filter(deck => deck.id !== action.payload)
-    })
+      // Fetch
+      .addCase(fetchDecks.pending, (state) => {
+        state.status = "loading";
+      })
+      .addCase(fetchDecks.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.decks = action.payload;
+      })
+      .addCase(fetchDecks.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.error.message;
+      })
+      // Create
+      .addCase(createDeck.fulfilled, (state, action) => {
+        state.decks.push(action.payload);
+      })
+      // Update
+      .addCase(updateDeck.fulfilled, (state, action) => {
+        const updated = action.payload;
+        const index = state.decks.findIndex((deck) => deck.id === updated.id);
+        if (index !== -1) state.decks[index] = updated;
+      })
+      // Delete
+      .addCase(deleteDeck.fulfilled, (state, action) => {
+        state.decks = state.decks.filter((deck) => deck.id !== action.payload);
+      });
   },
 });
 
-export default decksSlice.reducer
+export default decksSlice.reducer;

--- a/client/src/features/goals/goalsSlice.js
+++ b/client/src/features/goals/goalsSlice.js
@@ -11,8 +11,11 @@ import {
 export const fetchGoals = createAsyncThunk(
   "goals/fetchGoals",
   async (userId = null) => {
-    // accept optional userId
-    const response = await getGoals(userId); // Call the API to get goals
+    let url = "/api/v1/goals";
+    if (userId) {
+      url += `?user_id=${userId}`;
+    } // accept optional userId
+    const response = await getGoals(url); // Call the API to get goals
     return response; // Return the response to store in Redux state
   }
 );

--- a/client/src/features/goals/goalsSlice.js
+++ b/client/src/features/goals/goalsSlice.js
@@ -1,102 +1,90 @@
-// createAsyncThunk is used for handling asynchronous actions instead of creating async logic manually
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import {
   getGoals,
   createGoal,
   updateGoal,
   removeGoal,
-} from "../../api/goalsApi"; // Import API functions
+} from "../../api/goalsApi";
 
-// Async thunk to fetch goals from the API
+// Async thunks
+
 export const fetchGoals = createAsyncThunk(
   "goals/fetchGoals",
   async (userId = null) => {
     let url = "/api/v1/goals";
     if (userId) {
       url += `?user_id=${userId}`;
-    } // accept optional userId
-    const response = await getGoals(url); // Call the API to get goals
-    return response; // Return the response to store in Redux state
+    }
+    const response = await getGoals(url);
+    return response;
   }
 );
 
-// Async Thunk for creating a new goal
 export const addGoal = createAsyncThunk("goals/addGoal", async (goalData) => {
-  const response = await createGoal(goalData); // API call to create a new goal
-  return response; // Return the created goal
+  const response = await createGoal(goalData);
+  return response;
 });
 
-// Async Thunk for updating an existing goal
 export const editGoal = createAsyncThunk("goals/editGoal", async (goalData) => {
-  const response = await updateGoal(goalData); // API call to update the goal
-  return response; // Return the updated goal
+  const response = await updateGoal(goalData);
+  return response;
 });
 
-// Async Thunk for deleting a goal
 export const deleteGoal = createAsyncThunk(
   "goals/deleteGoal",
   async (goalId) => {
-    await removeGoal(goalId); // API call to delete the goal
-    return goalId; // Return the ID of the deleted goal
+    await removeGoal(goalId);
+    return goalId;
   }
 );
 
-// Define the initial state of the goals slice
+// Initial state
 const initialState = {
-  goals: [], // Holds the list of goals
-  loading: false, // Indicates if goals are being loaded from the API
-  error: null, // Holds error messages if the API call fails
+  goals: [],
+  loading: false,
+  error: null,
 };
 
-// Create a slice of the Redux store for goals
+// Slice
 const goalsSlice = createSlice({
   name: "goals",
   initialState,
   reducers: {
-    // Action to add the goals in the state
     setGoals: (state, action) => {
-      state.goals = action.payload; // Set the goals in the state
+      state.goals = action.payload;
     },
   },
   extraReducers: (builder) => {
     builder
-      // Handle the fetchGoals action
       .addCase(fetchGoals.pending, (state) => {
-        state.loading = true; // Set loading to true when fetching goals
-        state.error = null; // Reset error
+        state.loading = true;
+        state.error = null;
       })
-      // Handle the fetchGoals fulfilled action
       .addCase(fetchGoals.fulfilled, (state, action) => {
-        state.loading = false; // Set loading to false when fetching is done
-        state.goals = action.payload; // Set the fetched goals in the state
+        state.loading = false;
+        state.goals = action.payload;
       })
-      // Handle fetch error
       .addCase(fetchGoals.rejected, (state, action) => {
-        state.loading = false; // Set loading to false when fetching fails
-        state.error = action.error.message; // Set the error message
+        state.loading = false;
+        state.error = action.error.message;
       })
-
-      // Handle if goal is added successfully
       .addCase(addGoal.fulfilled, (state, action) => {
-        state.goals.push(action.payload); // Add the new goal to the state
+        state.goals.push(action.payload);
       })
-
-      // Handle if goal is updated successfully
       .addCase(editGoal.fulfilled, (state, action) => {
-        const updated = action.payload; // Updated goal from backend
-        const index = state.goals.findIndex((goal) => goal.id === updated.id); // Find the index of the updated goal
+        const updated = action.payload;
+        const index = state.goals.findIndex((goal) => goal.id === updated.id);
         if (index !== -1) {
-          state.goals[index] = updated; // Update the goal in the state
+          state.goals[index] = updated;
         }
       })
-
-      // Handle if goal is deleted successfully
       .addCase(deleteGoal.fulfilled, (state, action) => {
-        const idToRemove = action.payload; // ID of the goal to remove
-        state.goals = state.goals.filter((goal) => goal.id !== idToRemove); // Remove the goal from the state
+        const idToRemove = action.payload;
+        state.goals = state.goals.filter((goal) => goal.id !== idToRemove);
       });
   },
 });
 
-export const { setGoals } = goalsSlice.actions; // Export the action to set goals
-export default goalsSlice.reducer; // Export the reducer to be used in the store
+// Exports
+export const { setGoals } = goalsSlice.actions;
+export default goalsSlice.reducer;

--- a/client/src/features/goals/goalsSlice.js
+++ b/client/src/features/goals/goalsSlice.js
@@ -1,12 +1,21 @@
 // createAsyncThunk is used for handling asynchronous actions instead of creating async logic manually
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import { getGoals, createGoal, updateGoal, removeGoal } from "../../api/goalsApi"; // Import API functions
+import {
+  getGoals,
+  createGoal,
+  updateGoal,
+  removeGoal,
+} from "../../api/goalsApi"; // Import API functions
 
 // Async thunk to fetch goals from the API
-export const fetchGoals = createAsyncThunk("goals/fetchGoals", async () => {
-  const response = await getGoals(); // Call the API to get goals
-  return response; // Return the response to store in Redux state
-});
+export const fetchGoals = createAsyncThunk(
+  "goals/fetchGoals",
+  async (userId = null) => {
+    // accept optional userId
+    const response = await getGoals(userId); // Call the API to get goals
+    return response; // Return the response to store in Redux state
+  }
+);
 
 // Async Thunk for creating a new goal
 export const addGoal = createAsyncThunk("goals/addGoal", async (goalData) => {
@@ -21,10 +30,13 @@ export const editGoal = createAsyncThunk("goals/editGoal", async (goalData) => {
 });
 
 // Async Thunk for deleting a goal
-export const deleteGoal = createAsyncThunk("goals/deleteGoal", async (goalId) => {
-  await removeGoal(goalId); // API call to delete the goal
-  return goalId; // Return the ID of the deleted goal
-});
+export const deleteGoal = createAsyncThunk(
+  "goals/deleteGoal",
+  async (goalId) => {
+    await removeGoal(goalId); // API call to delete the goal
+    return goalId; // Return the ID of the deleted goal
+  }
+);
 
 // Define the initial state of the goals slice
 const initialState = {
@@ -84,4 +96,4 @@ const goalsSlice = createSlice({
 });
 
 export const { setGoals } = goalsSlice.actions; // Export the action to set goals
-export default goalsSlice.reducer; // Export the reducer to be used in the store 
+export default goalsSlice.reducer; // Export the reducer to be used in the store

--- a/client/src/features/studySessions/studySessionSlice.js
+++ b/client/src/features/studySessions/studySessionSlice.js
@@ -1,4 +1,5 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { createStudySession } from "../../api/studySessionsApi"; // use your API helper
 
 const initialState = {
   deckId: null,
@@ -9,6 +10,19 @@ const initialState = {
   notes: "",
   sessionHistory: [],
 };
+
+// THUNK: submits a finished session to the server
+export const submitStudySession = createAsyncThunk(
+  "studySession/submit",
+  async (sessionData, { rejectWithValue }) => {
+    try {
+      const response = await createStudySession({ study_session: sessionData });
+      return response;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || error.message);
+    }
+  }
+);
 
 const studySessionSlice = createSlice({
   name: "studySession",
@@ -27,7 +41,7 @@ const studySessionSlice = createSlice({
     endSession: (state, action) => {
       const { endTime, duration } = action.payload;
       state.endTime = endTime;
-      state.durationMin = typeof duration === 'number' ? duration : 0;
+      state.durationMin = typeof duration === "number" ? duration : 0;
     },
     addNotes: (state, action) => {
       state.notes = action.payload;
@@ -36,7 +50,7 @@ const studySessionSlice = createSlice({
       const history = state.sessionHistory;
       return {
         ...initialState,
-        sessionHistory: history
+        sessionHistory: history,
       };
     },
     //Log sessions
@@ -46,18 +60,30 @@ const studySessionSlice = createSlice({
 
       const newLog = {
         deckId,
-        startTime, 
-        endTime, 
-        durationMin, 
+        startTime,
+        endTime,
+        durationMin,
         notes,
         goalId, // Include goalId in the log
       };
 
       state.sessionHistory.push(newLog);
-    }
-  }
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(submitStudySession.pending, (state) => {
+        // you can add loading flag later if you want
+      })
+      .addCase(submitStudySession.fulfilled, (state, action) => {
+        console.log("Study session saved successfully:", action.payload);
+      })
+      .addCase(submitStudySession.rejected, (state, action) => {
+        console.error("Failed to save study session:", action.payload);
+      });
+  },
 });
 
-
-export const { startSession, endSession, addNotes, resetSession, logSession } = studySessionSlice.actions;
+export const { startSession, endSession, addNotes, resetSession, logSession } =
+  studySessionSlice.actions;
 export default studySessionSlice.reducer;

--- a/client/src/features/studySessions/studySessionSlice.js
+++ b/client/src/features/studySessions/studySessionSlice.js
@@ -1,15 +1,8 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import { createStudySession } from "../../api/studySessionsApi"; // use your API helper
-
-const initialState = {
-  deckId: null,
-  goalId: null, // goalId field added to track the goal associated with the session
-  startTime: null,
-  endTime: null,
-  durationMin: 0,
-  notes: "",
-  sessionHistory: [],
-};
+import {
+  createStudySession,
+  getStudySessions,
+} from "../../api/studySessionsApi"; // use your API helper
 
 // THUNK: submits a finished session to the server
 export const submitStudySession = createAsyncThunk(
@@ -23,6 +16,29 @@ export const submitStudySession = createAsyncThunk(
     }
   }
 );
+
+export const fetchStudySessions = createAsyncThunk(
+  "studySession/fetchAll",
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await getStudySessions();
+      return response;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || error.message);
+    }
+  }
+);
+
+const initialState = {
+  deckId: null,
+  goalId: null, // goalId field added to track the goal associated with the session
+  startTime: null,
+  endTime: null,
+  durationMin: 0,
+  notes: "",
+  sessionHistory: [],
+  fetchedSessions: [],
+};
 
 const studySessionSlice = createSlice({
   name: "studySession",
@@ -72,14 +88,20 @@ const studySessionSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(submitStudySession.pending, (state) => {
-        // you can add loading flag later if you want
-      })
+      .addCase(submitStudySession.pending, (state) => {})
       .addCase(submitStudySession.fulfilled, (state, action) => {
         console.log("Study session saved successfully:", action.payload);
       })
       .addCase(submitStudySession.rejected, (state, action) => {
         console.error("Failed to save study session:", action.payload);
+      })
+      // NEW
+      .addCase(fetchStudySessions.fulfilled, (state, action) => {
+        console.log("Fetched sessions:", action.payload);
+        state.fetchedSessions = action.payload; // replace fetched sessions
+      })
+      .addCase(fetchStudySessions.rejected, (state, action) => {
+        console.error("Failed to fetch study sessions:", action.payload);
       });
   },
 });

--- a/client/src/hooks/useGoals.js
+++ b/client/src/hooks/useGoals.js
@@ -6,13 +6,15 @@ import {
   deleteGoal,
 } from "../features/goals/goalsSlice"; // Import AsyncThunks from goalsSlice
 
-// Custom hhok to handle goal-related actions and state
+// Custom hook to handle goal-related actions and state
 const useGoals = () => {
   const dispatch = useDispatch(); // Dispatch function to trigger Redux actions
   const { goals, loading, error } = useSelector((state) => state.goals); // Select goals state from Redux store
+  const authUser = useSelector((state) => state.auth.user);
 
   // Function to fetch goals (now accepts optional userId)
-  const loadAllGoals = (userId = null) => {
+  const loadAllGoals = () => {
+    const userId = authUser?.id || null;
     dispatch(fetchGoals(userId));
   };
 

--- a/client/src/hooks/useGoals.js
+++ b/client/src/hooks/useGoals.js
@@ -11,9 +11,9 @@ const useGoals = () => {
   const dispatch = useDispatch(); // Dispatch function to trigger Redux actions
   const { goals, loading, error } = useSelector((state) => state.goals); // Select goals state from Redux store
 
-  // Function to fetch goals from the API
-  const loadAllGoals = () => {
-    dispatch(fetchGoals()); // Dispatch the fetchGoals action
+  // Function to fetch goals (now accepts optional userId)
+  const loadAllGoals = (userId = null) => {
+    dispatch(fetchGoals(userId));
   };
 
   // Function to add a new goal

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,11 +1,35 @@
-import { useSelector } from 'react-redux';
-import work from "../assets/work.png";	
-import ReviewQueue from '../components/ReviewQueue';
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchStudySessions } from "../features/studySessions/studySessionSlice";
+import { fetchDecks } from "../features/decks/decksSlice"; // fixed import
+import { fetchGoals } from "../features/goals/goalsSlice";
+import work from "../assets/work.png";
+import ReviewQueue from "../components/ReviewQueue";
 import { CalendarSync, History } from "lucide-react";
-import StudyHistory from '../components/StudyHistory';
+import StudyHistory from "../components/StudyHistory";
+
 export default function HomePage() {
+  const dispatch = useDispatch();
   const session = useSelector((state) => state.studySession);
   const user_name = useSelector((state) => state.auth.user?.username);
+  const authUser = useSelector((state) => state.auth.user);
+  const sessions = useSelector((state) => state.studySession.fetchedSessions);
+
+  const userSessions = sessions.filter(
+    (session) => session.user_id === authUser?.id
+  );
+
+  useEffect(() => {
+    if (authUser?.id) {
+      dispatch(fetchDecks(authUser.id));
+      dispatch(fetchGoals(authUser.id));
+    }
+  }, [authUser, dispatch]);
+
+  useEffect(() => {
+    dispatch(fetchStudySessions());
+  }, [dispatch]);
+
   return (
     <>
       <div className="welcome-user">
@@ -15,19 +39,31 @@ export default function HomePage() {
       </div>
       <div className="grid-container mt20">
         <div className="grid-col-6 history-grid">
-          <div className='row-span-2'>
-            <h2 className="grid-title"><span className='icon peach'><History /></span> Study History</h2>
-            <StudyHistory sessionHistory={session.sessionHistory} />
+          <div className="row-span-2">
+            <h2 className="grid-title">
+              <span className="icon peach">
+                <History />
+              </span>{" "}
+              Study History
+            </h2>
+            <StudyHistory
+              sessionHistory={
+                userSessions.length > 0 ? userSessions : session.sessionHistory
+              }
+            />
           </div>
           <div>
-            <h2 className="grid-title"><span className="icon yellow"><CalendarSync /></span> Spaced Repetition</h2>
+            <h2 className="grid-title">
+              <span className="icon yellow">
+                <CalendarSync />
+              </span>{" "}
+              Spaced Repetition
+            </h2>
             <ReviewQueue />
           </div>
         </div>
-        <div className="grid-col-3">
-        </div>
-        <div className="grid-col-3">
-        </div>
+        <div className="grid-col-3"></div>
+        <div className="grid-col-3"></div>
       </div>
     </>
   );

--- a/client/src/pages/Decks.jsx
+++ b/client/src/pages/Decks.jsx
@@ -1,30 +1,31 @@
-import { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import {
   fetchDecks,
   createDeck,
   updateDeck,
   deleteDeck,
-} from '../features/decks/decksSlice';
+} from "../features/decks/decksSlice";
 
-import DeckCard from '../components/DeckCard';
-import Button from '../components/Button';
-import Input from '../components/Input';
-import Textarea from '../components/Textarea';
-import ToggleSwitch from '../components/ToggleSwitch';
-import { CirclePlus } from 'lucide-react';
+import DeckCard from "../components/DeckCard";
+import Button from "../components/Button";
+import Input from "../components/Input";
+import Textarea from "../components/Textarea";
+import ToggleSwitch from "../components/ToggleSwitch";
+import { CirclePlus } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
 
 const Decks = () => {
   const dispatch = useDispatch();
-  const { decks, status, error } = useSelector(state => state.decks);
+  const { decks, status, error } = useSelector((state) => state.decks);
+  const authUser = useSelector((state) => state.auth.user); // get logged in user
 
   // State for the new deck creation form
   const [newDeck, setNewDeck] = useState({
-    title: '',
-    description: '',
+    title: "",
+    description: "",
     is_public: false,
-    user_id: 1
+    user_id: 1,
   });
 
   // Toggle visibility of new deck creation form
@@ -33,22 +34,26 @@ const Decks = () => {
   // State to manage deck editing
   const [editingDeckId, setEditingDeckId] = useState(null);
   const [editForm, setEditForm] = useState({
-    title: '',
-    description: '',
-    is_public: false
+    title: "",
+    description: "",
+    is_public: false,
   });
 
-  // Fetch decks from the backend when component mounts
+  // Fetch decks based on logged in user (or all)
   useEffect(() => {
-    if (status === 'idle') {
+    if (authUser?.id) {
+      // If a user is logged in, fetch only their decks
+      dispatch(fetchDecks(authUser.id));
+    } else if (status === "idle") {
+      // If no user, fetch all decks (public browsing maybe)
       dispatch(fetchDecks());
     }
-  }, [dispatch, status]);
+  }, [dispatch, authUser]);
 
   // Create a new deck
   const handleCreate = () => {
     dispatch(createDeck(newDeck));
-    setNewDeck({ title: '', description: '', is_public: false, user_id: 1 });
+    setNewDeck({ title: "", description: "", is_public: false, user_id: 1 });
     setAddNewDeck(false);
   };
 
@@ -88,9 +93,10 @@ const Decks = () => {
       </div>
 
       {/* New deck creation form with animation */}
-      <AnimatePresence mode="wait">  
+      <AnimatePresence mode="wait">
         {addNewDeck && (
-          <motion.div className='deck-goal-create'
+          <motion.div
+            className="deck-goal-create"
             key="decks"
             initial={{ opacity: 0, y: -30 }}
             animate={{ opacity: 1, y: 0 }}
@@ -101,30 +107,36 @@ const Decks = () => {
             <Input
               type="text"
               value={newDeck.title}
-              onChange={(e) => setNewDeck({ ...newDeck, title: e.target.value })}
+              onChange={(e) =>
+                setNewDeck({ ...newDeck, title: e.target.value })
+              }
               label="Title"
             />
             <Textarea
               value={newDeck.description}
-              onChange={(e) => setNewDeck({ ...newDeck, description: e.target.value })}
+              onChange={(e) =>
+                setNewDeck({ ...newDeck, description: e.target.value })
+              }
               label="Description"
             />
-            <ToggleSwitch 
-              isPublic={newDeck.is_public}  
+            <ToggleSwitch
+              isPublic={newDeck.is_public}
               onChange={(newVal) =>
                 setNewDeck({ ...newDeck, is_public: newVal })
-              } 
+              }
             />
             <div className="btn-row mt20">
               <Button onClick={handleCreate}>Create Deck</Button>
-              <Button variant='secondary' onClick={handleNewDeck}>Cancel</Button>
+              <Button variant="secondary" onClick={handleNewDeck}>
+                Cancel
+              </Button>
             </div>
           </motion.div>
         )}
       </AnimatePresence>
 
       {/* Render loading or deck list */}
-      {status === 'loading' ? (
+      {status === "loading" ? (
         <p>Loading...</p>
       ) : (
         decks.map((deck) => (

--- a/client/src/pages/Study.jsx
+++ b/client/src/pages/Study.jsx
@@ -1,13 +1,45 @@
-import BackgroundStudy from '../components/BackgroundStudy';
-import ForegroundStudy from '../components/ForegroundStudy';
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import BackgroundStudy from "../components/BackgroundStudy";
+import ForegroundStudy from "../components/ForegroundStudy";
 import StudySession from "../components/StudySession";
-
+import axios from "../api/axios";
 
 const Study = () => {
+  const { deckId, goalId } = useParams();
+  const [resolvedDeckId, setResolvedDeckId] = useState(null);
+
+  useEffect(() => {
+    const resolveDeckId = async () => {
+      if (goalId) {
+        try {
+          const response = await axios.get(`/api/v1/goals/${goalId}`);
+          const goal = response.data;
+          if (goal.deck_id) {
+            setResolvedDeckId(goal.deck_id);
+          } else {
+            console.error("Goal does not have an associated deck_id.");
+          }
+        } catch (error) {
+          console.error("Failed to fetch goal:", error);
+        }
+      } else if (deckId) {
+        setResolvedDeckId(deckId);
+      }
+    };
+
+    resolveDeckId();
+  }, [deckId, goalId]);
+
+  if (!resolvedDeckId) {
+    return <p>Loading study session...</p>; // optional loading screen
+  }
+
   return (
-    <div className="study-page">      
-      <BackgroundStudy />
-      <ForegroundStudy />
+    <div className="study-page">
+      <BackgroundStudy deckId={resolvedDeckId} />
+      <ForegroundStudy deckId={resolvedDeckId} />
+      <StudySession deckId={resolvedDeckId} />
     </div>
   );
 };

--- a/client/src/pages/Study.jsx
+++ b/client/src/pages/Study.jsx
@@ -32,14 +32,16 @@ const Study = () => {
   }, [deckId, goalId]);
 
   if (!resolvedDeckId) {
-    return <p>Loading study session...</p>; // optional loading screen
+    return <p>Loading study session...</p>;
   }
 
   return (
     <div className="study-page">
-      <BackgroundStudy deckId={resolvedDeckId} />
-      <ForegroundStudy deckId={resolvedDeckId} />
-      <StudySession deckId={resolvedDeckId} />
+      <BackgroundStudy deckId={resolvedDeckId} goalId={goalId} />
+      <ForegroundStudy deckId={resolvedDeckId} goalId={goalId} />
+      {resolvedDeckId && (
+        <StudySession deckId={resolvedDeckId} goalId={goalId} />
+      )}
     </div>
   );
 };

--- a/server/app/controllers/api/v1/decks_controller.rb
+++ b/server/app/controllers/api/v1/decks_controller.rb
@@ -12,10 +12,10 @@ class Api::V1::DecksController < ApplicationController
   # Returns all decks or filters by user_id if provided
   def index
     @decks = if params[:user_id]
-      # Logged in user
-      Deck.where("user_id = ? OR is_public = ?", params[:user_id], true)
+      # Logged in user: only show THEIR decks (public or private)
+      Deck.where(user_id: params[:user_id])
     else
-      # Not logged in
+      # Not logged in: only show public decks
       Deck.where(is_public: true)
     end
 

--- a/server/app/controllers/api/v1/decks_controller.rb
+++ b/server/app/controllers/api/v1/decks_controller.rb
@@ -12,9 +12,11 @@ class Api::V1::DecksController < ApplicationController
   # Returns all decks or filters by user_id if provided
   def index
     @decks = if params[:user_id]
-      Deck.where(user_id: params[:user_id])
+      # Logged in user
+      Deck.where("user_id = ? OR is_public = ?", params[:user_id], true)
     else
-      Deck.all
+      # Not logged in
+      Deck.where(is_public: true)
     end
 
     render :index, formats: :json

--- a/server/app/controllers/api/v1/goals_controller.rb
+++ b/server/app/controllers/api/v1/goals_controller.rb
@@ -12,10 +12,10 @@ module Api
       # Returns goals based on user_id (or only public goals if no user)
       def index
         @goals = if params[:user_id]
-          # Logged in user: get their own goals + all public goals
-          Goal.where("user_id = ? OR is_public = ?", params[:user_id], true)
+          # Logged in: show all goals belonging to that user (private or public)
+          Goal.where(user_id: params[:user_id])
         else
-          # No user logged in: show only public goals
+          # Not logged in: show only public goals
           Goal.where(is_public: true)
         end
 

--- a/server/app/controllers/api/v1/goals_controller.rb
+++ b/server/app/controllers/api/v1/goals_controller.rb
@@ -9,12 +9,14 @@ module Api
   module V1
     class GoalsController < ApplicationController
       # GET /api/v1/goals or /api/v1/goals?user_id=1
-      # Returns all goals or goals belonging to a specific user
+      # Returns goals based on user_id (or only public goals if no user)
       def index
         @goals = if params[:user_id]
-          Goal.where(user_id: params[:user_id])
+          # Logged in user: get their own goals + all public goals
+          Goal.where("user_id = ? OR is_public = ?", params[:user_id], true)
         else
-          Goal.all
+          # No user logged in: show only public goals
+          Goal.where(is_public: true)
         end
 
         render :index, formats: :json

--- a/server/app/controllers/api/v1/goals_controller.rb
+++ b/server/app/controllers/api/v1/goals_controller.rb
@@ -59,7 +59,7 @@ module Api
 
       # Strong parameters for goal creation/updating
       def goal_params
-        params.require(:goal).permit(:user_id, :title, :description, :target_hours, :is_public)
+        params.require(:goal).permit(:user_id, :title, :description, :target_hours, :is_public, :deck_id)
       end
     end
   end

--- a/server/app/views/api/v1/goals/_goal.json.jbuilder
+++ b/server/app/views/api/v1/goals/_goal.json.jbuilder
@@ -1,3 +1,3 @@
 # Partial to render a single goal in consistent format
-json.extract! goal, :id, :title, :description, :target_hours, :is_public, :created_at
+json.extract! goal, :id, :title, :description, :target_hours, :is_public, :created_at, :deck_id
 json.user_id goal.user_id

--- a/server/db/migrate/20250428052243_add_deck_id_to_goals.rb
+++ b/server/db/migrate/20250428052243_add_deck_id_to_goals.rb
@@ -1,0 +1,6 @@
+class AddDeckIdToGoals < ActiveRecord::Migration[7.1]
+  def change
+    add_column :goals, :deck_id, :integer
+    add_foreign_key :goals, :decks
+  end
+end

--- a/server/db/migrate/20250428052243_add_deck_id_to_goals.rb
+++ b/server/db/migrate/20250428052243_add_deck_id_to_goals.rb
@@ -1,6 +1,5 @@
 class AddDeckIdToGoals < ActiveRecord::Migration[7.1]
   def change
-    add_column :goals, :deck_id, :integer
-    add_foreign_key :goals, :decks
+    add_reference :goals, :deck, null: false, foreign_key: true
   end
 end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -113,7 +113,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_28_052243) do
     t.boolean "is_public"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "deck_id"
+    t.bigint "deck_id", null: false
+    t.index ["deck_id"], name: "index_goals_on_deck_id"
     t.index ["user_id"], name: "index_goals_on_user_id"
   end
 

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_13_033341) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_28_052243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -113,6 +113,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_13_033341) do
     t.boolean "is_public"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "deck_id"
     t.index ["user_id"], name: "index_goals_on_user_id"
   end
 
@@ -246,6 +247,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_13_033341) do
   add_foreign_key "flashcards", "decks"
   add_foreign_key "followings", "users", column: "followed_id"
   add_foreign_key "followings", "users", column: "follower_id"
+  add_foreign_key "goals", "decks"
   add_foreign_key "goals", "users"
   add_foreign_key "media_uploads", "flashcards"
   add_foreign_key "media_uploads", "users"

--- a/server/db/seeds.rb
+++ b/server/db/seeds.rb
@@ -45,19 +45,6 @@ puts "🌱 Creating additional users..."
   )
 end
 
-puts "🌱 Creating goals..."
-goals = users.flat_map do |user|
-  2.times.map do
-    Goal.create!(
-      user: user,
-      title: Faker::Educator.subject,
-      description: Faker::Lorem.sentence(word_count: 8),
-      target_hours: rand(10..50),
-      is_public: [true, false].sample
-    )
-  end
-end
-
 puts "🌱 Creating decks and flashcards..."
 decks = users.flat_map do |user|
   2.times.map do
@@ -70,7 +57,7 @@ decks = users.flat_map do |user|
 
     5.times do
       Flashcard.create!(
-        deck: deck,
+        deck_id: deck.id,
         front_text: Faker::Lorem.question,
         back_text: Faker::Lorem.sentence(word_count: 5),
         image_url: nil,
@@ -82,16 +69,55 @@ decks = users.flat_map do |user|
   end
 end
 
-puts "🌱 Creating study sessions..."
-goals.each do |goal|
-  2.times do
-    StudySession.create!(
-      user: goal.user,
-      goal: goal,
-      duration_min: rand(15..60),
-      notes: Faker::Lorem.sentence(word_count: 10)
-    )
-  end
+puts "🌱 Creating goals tied to decks..."
+goals = []
+
+decks.each do |deck|
+  # Goal 1: Completed Goal
+  complete_goal = Goal.create!(
+    user: deck.user,
+    deck_id: deck.id,
+    title: "Complete #{deck.title}",
+    description: "Complete all study hours for #{deck.title}",
+    target_hours: 10,
+    is_public: [true, false].sample
+  )
+  StudySession.create!(
+    user: deck.user,
+    goal: complete_goal,
+    duration_min: 600, # 10 hours completed
+    notes: "Completed full study goal!"
+  )
+  goals << complete_goal
+
+  # Goal 2: Partially Completed Goal
+  partial_goal = Goal.create!(
+    user: deck.user,
+    deck_id: deck.id,
+    title: "Work on #{deck.title}",
+    description: "Progress study goal for #{deck.title}",
+    target_hours: 10,
+    is_public: [true, false].sample
+  )
+  StudySession.create!(
+    user: deck.user,
+    goal: partial_goal,
+    duration_min: 240, # 4 hours done
+    notes: "Partial progress made."
+  )
+  goals << partial_goal
+
+  # Goal 3: Not Started Goal
+  new_goal = Goal.create!(
+    user: deck.user,
+    deck_id: deck.id,
+    title: "Start studying #{deck.title}",
+    description: "Begin studying #{deck.title}",
+    target_hours: 10,
+    is_public: [true, false].sample
+  )
+  # No study session yet — brand new goal
+  goals << new_goal
 end
 
 puts "✅ Seeding complete!"

--- a/server/server_tree.txt
+++ b/server/server_tree.txt
@@ -131,7 +131,8 @@ server
 │   │   ├── 20250413033320_create_media_uploads.rb
 │   │   ├── 20250413033326_create_challenges.rb
 │   │   ├── 20250413033336_create_user_challenges.rb
-│   │   └── 20250413033341_create_ai_requests.rb
+│   │   ├── 20250413033341_create_ai_requests.rb
+│   │   └── 20250428052243_add_deck_id_to_goals.rb
 │   ├── schema.rb
 │   └── seeds.rb
 ├── lib
@@ -139,4 +140,4 @@ server
 │       └── db.rake
 └── server_tree.txt
 
-31 directories, 108 files
+31 directories, 109 files


### PR DESCRIPTION
# Overview

This PR addresses a number of important fixes and improvements related to user-specific data handling across the application, particularly around goals, decks, and study sessions.

## Summary of Changes

- **Dashboard.jsx**  
  - Now fetches the logged-in user's decks and goals on load.
  - Filters study sessions by authenticated user before rendering history.
- **DecksSlice.js**  
  - Fixed exports and thunks for `fetchDecks` to support fetching by `user_id`.
  - Removed duplicate exports.
- **GoalsSlice.js**  
  - Fixed exports and thunks for `fetchGoals` to support fetching by `user_id`.
  - Cleaned up to prevent duplicate exports and errors.
- **StudySessionsSlice.js**  
  - Improved session fetching and separated user filtering into client-side logic.
- **StudyHistory.jsx**  
  - Updated to correctly show study session data even if the deck title isn't immediately available.
- **StudySessionsApi.js**  
  - Minor cleanup for consistency with updated session handling.

## Context / Related Changes

- **Decks and Goals now respect privacy and ownership:**  
  - If no user is logged in → Only public decks and public goals are visible.
  - If a user is logged in → Their private decks and goals are fetched and shown appropriately.
- **Goals are now properly associated with Decks:**  
  - Goals now correctly link to a valid `deck_id`, allowing dashboards to reference deck titles reliably.
- **Database updates:**  
  - Database was migrated and reseeded to fix deck/goal association issues.
- **Session logging improvements:**  
  - Study sessions now correctly initialize and avoid invalid resets on mount.

## Why These Changes Matter

- Without these fixes, the dashboard would either show **no data** or **incorrect data** until a user manually visited `/decks` or `/goals`.
- Users were seeing *all* study sessions across all users rather than just their own.
- Deck titles in study history were showing as `N/A` because deck/goal relationships weren't being resolved cleanly.
- Fixing the slices and API logic makes our Redux state consistent and predictable across the app.

## How to Test

1. Log in as a user.
2. Navigate directly to the dashboard (`/`).
3. Verify:
   - The **Study History** now shows the logged-in user's own sessions only.
   - The **deck titles** show correctly (no more "N/A" unless truly missing).
   - The **Spaced Repetition Queue** loads without needing manual refreshes.
4. Log out and observe:
   - Only public decks and public goals are visible.
   - No private study data from other users is leaked.

## Future Improvements

- Refactor StudyHistory to preload deck titles more efficiently if scaling to large user bases.
- Optimize API responses to return full session context including goal and deck titles (instead of piecing it together client-side).
- Add unit tests for the new dashboard data-loading behavior.

## Related Commits (Chronological)

- Update controller to handle decks by user_id
- Update deckSlice and Decks.jsx to handle decks by user_id
- Fix: Goals should now show based on the user_id for the logged in user
- Fix: Goal privacy is now respected
- Fix: Goals should show only public if not logged in or the users if logged in
- Fix: Decks should show only public if not logged in or the users if logged in
- Update: goals are now associated to decks
- Update: Migrate db and reseeded
- Fix: goals controller now accepts decks or goal id
- Fix: Goals table now actually links to a real deck id
- Fix: provide deck id with goals
- Trying to fix study sessions
- Fix: properly initialize study session and remove invalid reset on mount
- Update: server tree
- **Fix: preload user decks and goals on dashboard** ← [This PR]
